### PR TITLE
Rename Microsoft.DotNet namespace to Devlooped

### DIFF
--- a/src/File/AddCommand.cs
+++ b/src/File/AddCommand.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using ColoredConsole;
 using DotNetConfig;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class AddCommand : Command
     {

--- a/src/File/ChangesCommand.cs
+++ b/src/File/ChangesCommand.cs
@@ -1,6 +1,6 @@
 ﻿using DotNetConfig;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class ChangesCommand : UpdateCommand
     {

--- a/src/File/Command.cs
+++ b/src/File/Command.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotNetConfig;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     abstract class Command
     {

--- a/src/File/DeleteCommand.cs
+++ b/src/File/DeleteCommand.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotNetConfig;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class DeleteCommand : Command
     {

--- a/src/File/FileSpec.cs
+++ b/src/File/FileSpec.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     public class FileSpec
     {

--- a/src/File/FileSpecComparer.cs
+++ b/src/File/FileSpecComparer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class FileSpecComparer : IEqualityComparer<FileSpec>
     {

--- a/src/File/GitHub.cs
+++ b/src/File/GitHub.cs
@@ -5,7 +5,7 @@ using ColoredConsole;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     public enum GitHubResult
     {

--- a/src/File/Http/AuthHandler.cs
+++ b/src/File/Http/AuthHandler.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     interface IAuthHandler
     {

--- a/src/File/Http/AzureRepoAuthHandler.cs
+++ b/src/File/Http/AzureRepoAuthHandler.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AzureRepos;
 using Microsoft.Git.CredentialManager;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class AzureRepoAuthHandler : AuthHandler
     {

--- a/src/File/Http/AzureRepoRawHandler.cs
+++ b/src/File/Http/AzureRepoRawHandler.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet.Http
+namespace Devlooped.Http
 {
     /// <summary>
     /// Converts URLs for dev.azure.com files into the corresponding API call.

--- a/src/File/Http/BitbucketAuthHandler.cs
+++ b/src/File/Http/BitbucketAuthHandler.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Atlassian.Bitbucket;
 using Microsoft.Git.CredentialManager;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class BitbucketAuthHandler : AuthHandler
     {

--- a/src/File/Http/BitbucketRawHandler.cs
+++ b/src/File/Http/BitbucketRawHandler.cs
@@ -3,7 +3,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     /// <summary>
     /// Converts URLs for github.com files into raw.githubusercontent.com.

--- a/src/File/Http/GitAuthHandler.cs
+++ b/src/File/Http/GitAuthHandler.cs
@@ -5,7 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     /// <summary>
     /// Middleware to handle authentication to requested URLs using GCM 

--- a/src/File/Http/GitHubAuthHandler.cs
+++ b/src/File/Http/GitHubAuthHandler.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using GitHub;
 using Microsoft.Git.CredentialManager;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class GitHubAuthHandler : AuthHandler
     {

--- a/src/File/Http/GitHubRawHandler.cs
+++ b/src/File/Http/GitHubRawHandler.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     /// <summary>
     /// Converts URLs for github.com files into raw.githubusercontent.com.

--- a/src/File/Http/HttpClientFactory.cs
+++ b/src/File/Http/HttpClientFactory.cs
@@ -1,8 +1,8 @@
 ﻿using System.Net;
 using System.Net.Http;
-using Microsoft.DotNet.Http;
+using Devlooped.Http;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     static class HttpClientFactory
     {

--- a/src/File/InitCommand.cs
+++ b/src/File/InitCommand.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using ColoredConsole;
 using DotNetConfig;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class InitCommand : Command
     {

--- a/src/File/ListCommand.cs
+++ b/src/File/ListCommand.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotNetConfig;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class ListCommand : Command
     {

--- a/src/File/Process.cs
+++ b/src/File/Process.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class Process
     {

--- a/src/File/Program.cs
+++ b/src/File/Program.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using DotNetConfig;
 using Mono.Options;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class Program
     {

--- a/src/File/SyncCommand.cs
+++ b/src/File/SyncCommand.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using DotNetConfig;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class SyncCommand : UpdateCommand
     {

--- a/src/File/UpdateCommand.cs
+++ b/src/File/UpdateCommand.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using DotNetConfig;
 
-namespace Microsoft.DotNet
+namespace Devlooped
 {
     class UpdateCommand : AddCommand
     {


### PR DESCRIPTION
We don't want to make it seem like this is a Microsoft-authored or supported tool.

Fixes #25