### PR TITLE
Allow generating a changelog for updated/synced files

### DIFF
--- a/src/File/File.csproj
+++ b/src/File/File.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly" Version="1.0.0" />
     <PackageReference Include="ColoredConsole" Version="1.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.37.0" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="DotNetConfig" Version="1.0.0-rc.1" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />

--- a/src/File/FileSpec.cs
+++ b/src/File/FileSpec.cs
@@ -11,8 +11,8 @@ namespace Devlooped
         }
 
         public FileSpec(string path, Uri? uri = null, string? etag = null, string? sha = null)
-            => (Path, Uri, ETag, Sha)
-            = (path, uri, etag, sha);
+            => (Path, Uri, ETag, Sha, NewSha)
+            = (path, uri, etag, sha, sha);
 
         public string Path { get; }
 
@@ -22,6 +22,12 @@ namespace Devlooped
 
         public string? Sha { get; }
 
+        public string? NewSha { get; set; }
+
         internal bool IsDefaultPath { get; }
+
+        public override int GetHashCode() => Path.GetHashCode();
+
+        public override bool Equals(object? obj) => obj is FileSpec other && other.Path.Equals(Path);
     }
 }

--- a/src/File/Help.txt
+++ b/src/File/Help.txt
@@ -15,3 +15,6 @@ Status
   ^ <- [url]   remote file is newer (ETags mismatch)
   ? <- [url]   local file not found for remote file
   x <- [url]   error processing the entry
+
+For sync/update commands, an optional `c|changelog` parameter can be passed to generate 
+a markdown file with links to commits for updated files.


### PR DESCRIPTION
Adds a new `-c|changelog` argument where you can specify an output markdown file to write the changes to (defaults to `dotnet-file.md` if only `-c` is specified). The markdown is a full changelog built by comparing the old and new sha for changed files (if the sha is available) using the GH CLI (to avoid having to configure an access token), since that's the same mechanism we already use for GH fetching of directories.

We do some minor emoji cleanup too since the REST API does not properly support them for now and instead returns multiple chars for them. Might be worth revisting/removing down the road, but commits stick to latin subset, it should work just fine.

Fixes #30