### PR TITLE
Use docopt.net for command-line parsing

### DIFF
--- a/src/File/File.csproj
+++ b/src/File/File.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="docopt.net" Version="0.8.0" />
+    <PackageReference Include="docopt.net" Version="0.8.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly" Version="1.0.8" />
     <PackageReference Include="ColoredConsole" Version="1.0.0" />

--- a/src/File/File.csproj
+++ b/src/File/File.csproj
@@ -17,18 +17,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Help.txt" />
     <None Include="..\..\readme.md" PackagePath="readme.md" Pack="true" />
-    <Content Include="Help.txt" CopyToOutputDirectory="PreserveNewest" Condition="'$(TargetFramework)' != ''" />
     <Compile Remove="Range.cs" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="docopt.net" Version="0.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
     <PackageReference Include="ThisAssembly" Version="1.0.8" />
     <PackageReference Include="ColoredConsole" Version="1.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.40.0" />
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
     <PackageReference Include="DotNetConfig" Version="1.0.0-rc.1" />
     <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
   </ItemGroup>

--- a/src/File/Program.cs
+++ b/src/File/Program.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using DotNetConfig;
-using Mono.Options;
 
 namespace Devlooped
 {
@@ -13,59 +10,56 @@ namespace Devlooped
     {
         static async Task<int> Main(string[] args)
         {
-            var help = false;
-            string? changelog = null;
-            var options = new OptionSet
+            var result = ProgramArguments.CreateParser()
+                                         .WithVersion(ThisAssembly.Info.Version)
+                                         .Parse(args);
+
+            return await result.Match(RunAsync,
+                                      r => PrintAsync(Console.Out, r.Help.Replace("dotnet-file", "dotnet file")),
+                                      r => PrintAsync(Console.Out, r.Version),
+                                      r => PrintAsync(Console.Error, r.Usage));
+
+            static Task<int> PrintAsync(TextWriter writer, string message, int exitCode = 0)
             {
-                { "?|h|help", "Display this help", h => help = h != null },
-                { "c|changelog:", "Write a changelog", c => changelog = string.IsNullOrEmpty(c) ? "dotnet-file.md" : c },
-            };
+                writer.WriteLine(message);
+                return Task.FromResult(exitCode);
+            }
+        }
 
-            var extraArgs = options.Parse(args);
-            if ((args.Length == 1 && help) || extraArgs.Count == 0)
-                return ShowHelp();
-
+        static async Task<int> RunAsync(ProgramArguments args)
+        {
             var config = Config.Build();
-            var command = extraArgs[0].ToLowerInvariant() switch
+            var command = args switch
             {
-                "add" => new AddCommand(config),
-                "changes" => new ChangesCommand(config),
-                "delete" => new DeleteCommand(config),
-                "init" => new InitCommand(config),
-                "list" => new ListCommand(config),
-                "sync" => new SyncCommand(config),
-                "update" => new UpdateCommand(config),
+                { CmdAdd    : true } => new AddCommand(config),
+                { CmdChanges: true } => new ChangesCommand(config),
+                { CmdDelete : true } => new DeleteCommand(config),
+                { CmdInit   : true } => new InitCommand(config),
+                { CmdList   : true } => new ListCommand(config),
+                { CmdSync   : true } => new SyncCommand(config),
+                { CmdUpdate : true } => new UpdateCommand(config),
                 _ => Command.NullCommand,
             };
 
             if (command == Command.NullCommand)
-                return ShowHelp();
-
-            // Remove first arg which is the command to use.
-            extraArgs.RemoveAt(0);
+            {
+                Console.Error.WriteLine(ProgramArguments.Usage);
+                return 1;
+            }
 
             // Add remainder arguments as if they were just files or urls provided 
             // to the command. Allows skipping the -f|-u switches.
-            var skip = false;
             var files = new List<FileSpec>();
-            for (var i = 0; i < extraArgs.Count; i++)
+            using (var fileOrUrl = args.ArgFileOrUrl.GetEnumerator())
             {
-                if (skip)
-                {
-                    skip = false;
-                    continue;
-                }
-
                 // Try to pair Uri+File to allow intuitive download>path mapping, such as 
                 // https://gitub.com/org/repo/docs/file.md docs/file.md
-                if (Uri.TryCreate(extraArgs[i], UriKind.Absolute, out var uri))
+                if (Uri.TryCreate(fileOrUrl.Current, UriKind.Absolute, out var uri))
                 {
-                    var next = i + 1;
                     // If the next arg is not a URI, use that as the file path for the uri
-                    if (next < extraArgs.Count && !Uri.TryCreate(extraArgs[next], UriKind.Absolute, out _))
+                    if (fileOrUrl.MoveNext() && !Uri.TryCreate(fileOrUrl.Current, UriKind.Absolute, out _))
                     {
-                        files.Add(FileSpec.WithPath(extraArgs[next], uri));
-                        skip = true;
+                        files.Add(FileSpec.WithPath(fileOrUrl.Current, uri));
                     }
                     else
                     {
@@ -82,25 +76,17 @@ namespace Devlooped
 
             var result = await command.ExecuteAsync();
 
-            // If there were changes and a changelog was requested, emit it 
+            // If there were changes and a changelog was requested, emit it
             // to a file.
-            if (changelog != null &&
+            if (args.OptChangelog is var changelog &&
                 command is AddCommand add &&
                 add.Changes.Count > 0 &&
                 GitHub.IsInstalled)
             {
-                GitHub.WriteChanges(changelog!, add.Changes);
+                GitHub.WriteChanges(changelog, add.Changes);
             }
 
             return result;
-        }
-
-        static int ShowHelp()
-        {
-            Console.WriteLine(File.ReadAllText(
-                Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!, "Help.txt")));
-
-            return 0;
         }
     }
 }

--- a/src/File/Program.docopt.txt
+++ b/src/File/Program.docopt.txt
@@ -1,6 +1,10 @@
-﻿Usage: dotnet file [add|changes|delete|init|list|sync|update] [file or url]*
+﻿Usage:
+    dotnet-file (add|changes|delete|init|list) <file-or-url>...
+    dotnet-file (sync|update) <file-or-url>... [--changelog=<md-file>]
+    dotnet-file --version
+    dotnet-file -h | --help
 
-Actions
+Actions:
     add        downloads a file or GitHub repository or directory from a URL
     changes    checks remote URLs for changes and lists the status of local files
     delete     deletes a file and its corresponding config entry from the local directory
@@ -9,12 +13,16 @@ Actions
     sync       synchronizes with remote URLs, deleting local files and directories as needed
     update     updates local files from remote URLs, does not prune deleted remote files
 
-Status
+Options:
+    -c, --changelog=<md-file>
+                  generate Markdown file with links to commits for updated files
+                    [default: dotnet-file.md]
+    -h, --help    show this screen
+    --version     show version
+
+Status:
   = <- [url]   remote file equals local file
   ✓ <- [url]   local file updated with remote file
   ^ <- [url]   remote file is newer (ETags mismatch)
   ? <- [url]   local file not found for remote file
   x <- [url]   error processing the entry
-
-For sync/update commands, an optional `c|changelog` parameter can be passed to generate 
-a markdown file with links to commits for updated files.


### PR DESCRIPTION
This PR proposes to replace **Mono.Options** with [**docopt.net**](http://docopt.github.io/docopt.net/) for command-line parsing. The benefits are better performance, reduced maintenance, consistency and strong compile-time guarantees. Here is a breakdown of how:

- Reduced maintenance; the help text file (`Help.txt` renamed to `Program.docopt.txt`) is the single source of usage and truth.
- If the text-based usage changes in an incompatible way then the solution will fail to compile so the chances of the C# source code going out of sync with the help is going to be next to zero.
- The text-based usage is based on [docopt], which is based on conventions that have been used for decades in help messages and man pages for describing a program's interface.
- **docopt.net** will [generate efficient command-line parsing code](https://gist.github.com/atifaziz/636f661bb8ca1ae75536f4c7834af2ef#file-programarguments-cs-L97-L333) at build-time (via its C# source generator) and a strong-typed class with [commands, arguments and options as its properties](https://gist.github.com/atifaziz/636f661bb8ca1ae75536f4c7834af2ef#file-programarguments-cs-L353-L384) (thus yielding the first two benefits).

## Summary of Changes

- `Help.txt` was renamed to `Program.docopt.txt` (**docopt.net** convention).
- `Help.txt` is no longer needed at runtime since the [help gets embedded into a string const](https://gist.github.com/atifaziz/636f661bb8ca1ae75536f4c7834af2ef#file-programarguments-cs-L13-L41) by **docopt.net**.
- Naturally, **Mono.Options** dependency is removed.
- Use of **Mono.Options** API has been replaced with direct use of properties of the arguments class generated by **docopt.net**.
- Added support for `--version` option that simply prints the program version.
- Removed support for `-?` as alias for help (though it could be added if strictly desired).
- Exit code is non-zero for invalid invocations/usage.
- The usage in the help file has been adjusted to use [docopt] conventions/language/syntax/grammar. The changes were very minimal and read more POSIX-y now.
- The usage has been made clearer about which options belong with which commands. For example, it is clear now that `--changelog` can only be supplied for `sync` or `update` command.

Some changes might have introduced incompatibilities, but I doubted anyone depended on the difference in behaviour. For example, invalid usages like the following will now return a non-zero exit code where zero was returned previously:

- Use of `--changelog` or `-c` with any other command but `update` or `sync`.
- When no command is given (previously displayed help and returned but now displays the usage and returns 1).

[docopt]: http://docopt.org/
