### PR TITLE
Remove submodule for gcm and use tool package instead

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "external/gcm"]
-	path = external/gcm
-	url = https://github.com/GitCredentialManager/git-credential-manager
-	branch = main

--- a/File.sln
+++ b/File.sln
@@ -3,28 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8722AC17-A90B-406B-850A-C1B8EB89056D}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-		.netconfig = .netconfig
-		src\Directory.props = src\Directory.props
-		src\Directory.targets = src\Directory.targets
-		readme.md = readme.md
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "File", "src\File\File.csproj", "{F98A74FE-B9B7-49EF-9E00-1911B4E244CB}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GCM", "GCM", "{F0D2DF05-3B25-467D-B27B-5D697C6ADE85}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GitHub", "external\gcm\src\shared\GitHub\GitHub.csproj", "{16C29C1C-E248-4DF5-84DA-DDF0D2ADD235}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Atlassian.Bitbucket", "external\gcm\src\shared\Atlassian.Bitbucket\Atlassian.Bitbucket.csproj", "{F51AD403-4C4B-4A09-AA7A-0C432982748E}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AzureRepos", "external\gcm\src\shared\Microsoft.AzureRepos\Microsoft.AzureRepos.csproj", "{2E5862BA-4B16-4619-9EAA-D347D39F728F}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tests", "src\Tests\Tests.csproj", "{86915414-399F-4B91-99C6-D64C987D9BF9}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "external\gcm\src\shared\Core\Core.csproj", "{A5295AF2-1260-45D9-B1CC-055685EA87AE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,35 +17,13 @@ Global
 		{F98A74FE-B9B7-49EF-9E00-1911B4E244CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F98A74FE-B9B7-49EF-9E00-1911B4E244CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F98A74FE-B9B7-49EF-9E00-1911B4E244CB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{16C29C1C-E248-4DF5-84DA-DDF0D2ADD235}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{16C29C1C-E248-4DF5-84DA-DDF0D2ADD235}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{16C29C1C-E248-4DF5-84DA-DDF0D2ADD235}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{16C29C1C-E248-4DF5-84DA-DDF0D2ADD235}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F51AD403-4C4B-4A09-AA7A-0C432982748E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F51AD403-4C4B-4A09-AA7A-0C432982748E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F51AD403-4C4B-4A09-AA7A-0C432982748E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F51AD403-4C4B-4A09-AA7A-0C432982748E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2E5862BA-4B16-4619-9EAA-D347D39F728F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2E5862BA-4B16-4619-9EAA-D347D39F728F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2E5862BA-4B16-4619-9EAA-D347D39F728F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2E5862BA-4B16-4619-9EAA-D347D39F728F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{86915414-399F-4B91-99C6-D64C987D9BF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{86915414-399F-4B91-99C6-D64C987D9BF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{86915414-399F-4B91-99C6-D64C987D9BF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{86915414-399F-4B91-99C6-D64C987D9BF9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A5295AF2-1260-45D9-B1CC-055685EA87AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A5295AF2-1260-45D9-B1CC-055685EA87AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A5295AF2-1260-45D9-B1CC-055685EA87AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A5295AF2-1260-45D9-B1CC-055685EA87AE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{16C29C1C-E248-4DF5-84DA-DDF0D2ADD235} = {F0D2DF05-3B25-467D-B27B-5D697C6ADE85}
-		{F51AD403-4C4B-4A09-AA7A-0C432982748E} = {F0D2DF05-3B25-467D-B27B-5D697C6ADE85}
-		{2E5862BA-4B16-4619-9EAA-D347D39F728F} = {F0D2DF05-3B25-467D-B27B-5D697C6ADE85}
-		{A5295AF2-1260-45D9-B1CC-055685EA87AE} = {F0D2DF05-3B25-467D-B27B-5D697C6ADE85}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {19B804F2-469A-40CA-9387-C9C1F7D231E8}

--- a/external/.editorconfig
+++ b/external/.editorconfig
@@ -1,3 +1,0 @@
-# ignore submodule
-[gcm/**]
-generated_code = true

--- a/src/Directory.props
+++ b/src/Directory.props
@@ -7,10 +7,6 @@
     <!-- Because PackOnBuild is sooo much better than GeneratePackageOnBuild! -->
     <GeneratePackageOnBuild>$(PackOnBuild)</GeneratePackageOnBuild>
     <PackageOutputPath Condition="'$(PackOnBuild)' == 'true' And '$(PackageOutputPath)' == ''">$(MSBuildThisFileDirectory)..\bin</PackageOutputPath>
-
-    <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin'));$(RestoreSources)</RestoreSources>
-    <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\dotnet-config\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\dotnet-config\bin'));$(RestoreSources)</RestoreSources>
-
     <PackageProjectUrl>https://clarius.org/dotnet-file</PackageProjectUrl>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/File/AppPath.cs
+++ b/src/File/AppPath.cs
@@ -1,8 +1,9 @@
-﻿using GitCredentialManager;
+﻿using System;
+using GitCredentialManager;
 
 namespace Devlooped;
 
 static class AppPath
 {
-    public static string Default { get; } = ApplicationBase.GetEntryApplicationPath();
+    public static string Default { get; } = CommandContext.GetEntryApplicationPath();
 }

--- a/src/File/File.csproj
+++ b/src/File/File.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>A dotnet global tool for downloading and updating loose files from arbitrary URLs.</Description>
 
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RollForward>Major</RollForward>
 
     <AssemblyName>file</AssemblyName>
@@ -23,19 +23,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="ThisAssembly" Version="1.0.8" />
     <PackageReference Include="ColoredConsole" Version="1.0.0" />
-    <PackageReference Include="Spectre.Console" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console" Version="0.48.0" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="DotNetConfig" Version="1.0.0-rc.1" />
+    <PackageReference Include="git-credential-manager" Version="2.4.1" IncludeAssets="tools" GeneratePathProperty="true" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\external\gcm\src\shared\Atlassian.Bitbucket\Atlassian.Bitbucket.csproj" />
-    <ProjectReference Include="..\..\external\gcm\src\shared\GitHub\GitHub.csproj" />
-    <ProjectReference Include="..\..\external\gcm\src\shared\Microsoft.AzureRepos\Microsoft.AzureRepos.csproj" />
-    <ProjectReference Include="..\..\external\gcm\src\shared\Core\Core.csproj" />
+  <ItemGroup Condition="'$(Pkggit-credential-manager)' != ''">
+    <Reference Include="Atlassian.Bitbucket" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\Atlassian.Bitbucket.dll" />
+    <Reference Include="Microsoft.AzureRepos" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\Microsoft.AzureRepos.dll" />
+    <Reference Include="GitHub" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\GitHub.dll" />
+    <Reference Include="GitLab" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\GitLab.dll" />
+    <Reference Include="gcmcore" HintPath="$(Pkggit-credential-manager)\tools\net7.0\any\gcmcore.dll" />
   </ItemGroup>
 
 </Project>

--- a/src/File/Http/AzureRepoAuthHandler.cs
+++ b/src/File/Http/AzureRepoAuthHandler.cs
@@ -46,7 +46,7 @@ namespace Devlooped
                 ["path"] = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped),
             });
 
-            var provider = new AzureReposHostProvider(new CommandContext(AppPath.Default));
+            var provider = new AzureReposHostProvider(new CommandContext());
             credential = await provider.GetCredentialAsync(input);
 
             return credential;

--- a/src/File/Http/BitbucketAuthHandler.cs
+++ b/src/File/Http/BitbucketAuthHandler.cs
@@ -48,7 +48,7 @@ namespace Devlooped
                 ["path"] = uri.GetComponents(UriComponents.Path, UriFormat.Unescaped),
             });
 
-            var provider = new BitbucketHostProvider(new CommandContext(AppPath.Default));
+            var provider = new BitbucketHostProvider(new CommandContext());
 
             credential = await provider.GetCredentialAsync(input);
             return credential;

--- a/src/File/Http/GitHubAuthHandler.cs
+++ b/src/File/Http/GitHubAuthHandler.cs
@@ -49,7 +49,7 @@ namespace Devlooped
                 ["host"] = "github.com",
             });
 
-            var provider = new GitHubHostProvider(new CommandContext(AppPath.Default));
+            var provider = new GitHubHostProvider(new CommandContext());
 
             credential = await provider.GetCredentialAsync(input);
             return credential;

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>File.Tests</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
We need to tweak a bit the reference since the package is a tool-only package. We'd need to match the .NET version in the tool to avoid mismatch in reference assemblies, moving forward.

This means we have to bump to .NET7 also.