### PR TITLE
Add a new relative target path heuristic with `/` in url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -63,10 +63,11 @@ Examples:
     dotnet file changes             // lists all configured files and their status with regards to the configured 
                                     // remote URL and ETag matching
 
-> NOTE: to download a file from GitHub to the current directory, ignoring the remote folder structure, 
-> specify `.` as the `[file]` argument after the `[url]`. Otherwise, the default will be to match the 
-> directory structure of the source file.  
-
+The target path is determined by the following rules:
+* If `[file]` = `.`: download to the current directory, ignoring the source directory structure.
+* If `[url]` ends with `/`: download to the current directory, preserving the source directory structure 
+  from that point onwards (i.e. for GitHub tree/dir URLs)
+* Otherwise, match the directory structure of the source file.  
 
 After downloading a file, a new entry is created in a local `.netconfig` file, which
 leverages [dotnet config](https://github.com/kzu/dotnet-config):

--- a/src/File/File.csproj
+++ b/src/File/File.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="ColoredConsole" Version="1.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.48.0" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="DotNetConfig" Version="1.1.1" />
+    <PackageReference Include="DotNetConfig" Version="1.2.0" />
     <PackageReference Include="git-credential-manager" Version="2.4.1" IncludeAssets="tools" GeneratePathProperty="true" />
   </ItemGroup>
 

--- a/src/File/FileSpec.cs
+++ b/src/File/FileSpec.cs
@@ -38,10 +38,17 @@ namespace Devlooped
                 // This is a whole directory URL, so use that as the base dir,
                 // denoted by the ending in a path separator. Note we skip 4 parts 
                 // since those are org/repo/tree/branch, then comes the actual dir.
-                return new FileSpec(
-                        flatten ? baseDir :
-                        baseDir.Length == 0 ? string.Join('/', parts.Skip(4)) :
-                        System.IO.Path.Combine(baseDir, string.Join('/', parts.Skip(4))).Replace('\\', '/') + "/",
+                return new FileSpec(flatten
+                    ? baseDir // Flattened folder structure, just use base dir as target path
+                    : baseDir.Length == 0 // Otherwise, perform some heuristics to determine the target path
+                        ? uri.PathAndQuery.EndsWith('/')
+                            // A URI ending in / has a similar effect to a target path ending in /, meaning 
+                            // Copy the whole directory structure to the target directory from that path onwards, 
+                            // without prepending the source (web) directory structure.
+                            ? ""
+                            // Otherwise, just like previous behavior, prepend upstream dir structure.
+                            : string.Join('/', parts.Skip(4))
+                        : System.IO.Path.Combine(baseDir, string.Join('/', parts.Skip(4))).Replace('\\', '/') + "/",
                     uri, finalPath: true);
             }
             else if (parts[2] == "blob" || parts[2] == "raw")

--- a/src/Tests/FileSpecTests.cs
+++ b/src/Tests/FileSpecTests.cs
@@ -36,6 +36,15 @@ namespace Devlooped
             Assert.Equal(expected, spec.Path);
         }
 
+        [Fact]
+        public void WhenSourceUriEndsInSlathThenTargetPathIsBaseDir()
+        {
+            var spec = new FileSpec("docs/", new Uri("https://github.com/devlooped/dotnet-file/tree/main/src/api/documentation/"));
+
+            // NOTE: the relative `src/api/documentation` is not appended to the file path.
+            Assert.Equal("docs", spec.Path);
+        }
+
         [Theory]
         [InlineData("https://github.com/devlooped/dotnet-file/blob/main/src/Foo.cs", ".", "Foo.cs")]
         [InlineData("https://github.com/devlooped/dotnet-file/blob/main/src/Foo.cs", "src/External/.", "src/External/Foo.cs")]


### PR DESCRIPTION
When the source url ends in `/`, work similarly to when the target file path ends with `/`, meaning "relative structure from here on". This allows mapping an abitrary subfolder in GitHub to a specific target base directory on the local machine.