### PR TITLE
Perform more optimal GCM API credentials retrieval if available

### DIFF
--- a/src/File/File.csproj
+++ b/src/File/File.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Devlooped.CredentialManager" Version="2.5.0.1" Aliases="Devlooped" />
     <PackageReference Include="NuGetizer" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="ThisAssembly" Version="1.0.8" />


### PR DESCRIPTION
The GCM binary retrieval may involve launching an auth UI which may not be available. By using the direct GCM API from the CredentialManager package, we can retrieve creds faster in most cases.