### PR TITLE
Smarter empty directory cleanup

### DIFF
--- a/src/File/FileSpec.cs
+++ b/src/File/FileSpec.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Devlooped
 {
+    [DebuggerDisplay("{Path}")]
     public class FileSpec
     {
         public static FileSpec WithPath(string path, Uri uri)

--- a/src/File/SyncCommand.cs
+++ b/src/File/SyncCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using DotNetConfig;
 
@@ -16,12 +17,21 @@ namespace Devlooped
 
             // Clear empty directories
             var dir = new FileInfo(spec.Path).DirectoryName;
-            if (dir != null && !Directory.EnumerateFiles(dir).Any())
-                Directory.Delete(dir);
+            DeleteEmptyDirectories(dir);
 
             Configuration.RemoveSection("file", spec.Path);
 
             return true;
+        }
+
+        void DeleteEmptyDirectories(string? dir)
+        {
+            if (dir != null && !Directory.EnumerateFiles(dir).Any() && !Directory.EnumerateDirectories(dir).Any())
+            {
+                var parent = new DirectoryInfo(dir).Parent?.FullName;
+                Directory.Delete(dir);
+                DeleteEmptyDirectories(parent);
+            }
         }
     }
 }


### PR DESCRIPTION
We were not detecting non-empty directies (that contained only subdirectories), and we were also not cleaning up parent directories once the descendent ones were empty.