### PR TITLE
Detect fetching folders/trees to avoid unnecessary auth

### DIFF
--- a/src/File/Http/GitHubAuthHandler.cs
+++ b/src/File/Http/GitHubAuthHandler.cs
@@ -22,6 +22,13 @@ namespace Devlooped
                 return await base.SendAsync(request, cancellationToken);
 
             var response = await base.SendAsync(request, cancellationToken);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.NotFound &&
+                request.RequestUri.Host.StartsWith("raw") &&
+                (request.RequestUri.PathAndQuery.Contains("/tree/") || request.Headers.Referrer?.PathAndQuery.Contains("/tree/") == true))
+                // These will always fail, don't try to auth in particular.
+                return response;
+
             if (response.StatusCode == System.Net.HttpStatusCode.Forbidden ||
                 response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {

--- a/src/File/Http/GitHubRawHandler.cs
+++ b/src/File/Http/GitHubRawHandler.cs
@@ -33,11 +33,15 @@ namespace Devlooped
             // NOTE: we WILL make a raw URL for top-level org/repo URLs too, causing a 
             // BadRequest or NotFound which is REQUIRED for AddCommand to detect and 
             // fallback to a gh CLI call, so DO NOT change that behavior here.
-
-            request.RequestUri = new Uri(new Uri("https://raw.githubusercontent.com/"), string.Join('/',
+            var rawUri = new Uri(new Uri("https://raw.githubusercontent.com/"), string.Join('/',
                 parts.Take(2).Concat(parts.Skip(3))));
 
+            // Move the original to the referer, so it can be used by other handlers.
+            request.Headers.Referrer = request.RequestUri;
+            request.RequestUri = rawUri;
+
             var response = await base.SendAsync(request, cancellationToken);
+
             var originalEtag = request.Headers.TryGetValues("X-ETag", out var etags) ? etags.FirstOrDefault() : null;
             var originalSha = request.Headers.TryGetValues("X-Sha", out var shas) ? shas.FirstOrDefault() : null;
 


### PR DESCRIPTION
The authentication step is only needed when actually fetching raw github resources that potentially exist. But raw URLs pointing to `/tree/` will always fail by definition (can't get the raw content of a folder).

Since the raw handler overwrites the request URI, we preserve the original URI as the Referrer, so it can be checked by other handlers.