### PR TITLE
Optimize retrieval and propagation of X-Sha

### DIFF
--- a/src/File/GitHub.cs
+++ b/src/File/GitHub.cs
@@ -33,6 +33,9 @@ namespace Devlooped
         public static bool TryIsInstalled(out string output)
             => Process.TryExecute("gh", "--version", out output) && output.StartsWith("gh version");
 
+        public static bool TryApi(string endpoint, string jq, out string? output)
+            => Process.TryExecute("gh", $"api {endpoint} --jq \"{jq}\"", out output);
+
         public static bool TryApi(string endpoint, out JToken? json)
         {
             json = null;


### PR DESCRIPTION
Simplify retrieval by leveraging JQ support in GH CLI, and always ensure we propagate the latest value for the X-Sha header.