### PR TITLE
Preserve trailing slash in file spec for directory

### DIFF
--- a/src/File/FileSpec.cs
+++ b/src/File/FileSpec.cs
@@ -106,18 +106,22 @@ namespace Devlooped
             Sha = sha;
             NewSha = sha;
 
-            if (!finalPath && uri != null &&
+            if (!finalPath && uri != null && !uri.AbsolutePath.EndsWith('/') &&
                 (path.EndsWith('\\') || path.EndsWith('/')))
             {
                 path = System.IO.Path.Combine(path, WithDefaultPath(uri!).Path);
             }
 
             // This will also normalize double slashes.
-            var parts = path.Split(new[] { '\\', '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var parts = path.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length > 0 && parts[0] == ".")
                 Path = string.Join('/', parts.Skip(1));
             else
                 Path = string.Join('/', parts);
+
+            // Preserve trailing slash if present, for consistency with url ending in /.
+            if (path.EndsWith('/') || path.EndsWith("\\"))
+                Path += "/";
         }
 
         public string Path { get; }

--- a/src/File/Program.cs
+++ b/src/File/Program.cs
@@ -59,7 +59,7 @@ namespace Devlooped
                 }
 
                 // Try to pair Uri+File to allow intuitive download>path mapping, such as 
-                // https://gitub.com/org/repo/docs/file.md docs/file.md
+                // https://gitub.com/org/repo/docs/file.md > docs/file.md
                 if (Uri.TryCreate(extraArgs[i], UriKind.Absolute, out var uri))
                 {
                     var next = i + 1;

--- a/src/Tests/FileSpecTests.cs
+++ b/src/Tests/FileSpecTests.cs
@@ -39,10 +39,19 @@ namespace Devlooped
         [Fact]
         public void WhenSourceUriEndsInSlathThenTargetPathIsBaseDir()
         {
-            var spec = new FileSpec("docs/", new Uri("https://github.com/devlooped/dotnet-file/tree/main/src/api/documentation/"));
+            var spec = new FileSpec("docs", new Uri("https://github.com/devlooped/dotnet-file/tree/main/src/api/documentation/"));
 
             // NOTE: the relative `src/api/documentation` is not appended to the file path.
             Assert.Equal("docs", spec.Path);
+        }
+
+        [Fact]
+        public void WhenSpecAndSourceUriEndInSlathThenPreservesBaseDirSlash()
+        {
+            var spec = new FileSpec("docs/", new Uri("https://github.com/devlooped/dotnet-file/tree/main/src/api/documentation/"));
+
+            // NOTE: the relative `src/api/documentation` is not appended to the file path.
+            Assert.Equal("docs/", spec.Path);
         }
 
         [Theory]


### PR DESCRIPTION
This enhances consistency with the `/` meaning "start relative path from here on", which can now be used consistently in both the path and url.