### PR TITLE
Allow preserving skips from init upstream file

### DIFF
--- a/src/File/File.csproj
+++ b/src/File/File.csproj
@@ -18,11 +18,11 @@
 
   <ItemGroup>
     <PackageReference Include="Devlooped.CredentialManager" Version="2.7.0" Aliases="Devlooped" />
-    <PackageReference Include="NuGetizer" Version="1.2.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="ThisAssembly" Version="1.0.8" />
+    <PackageReference Include="NuGetizer" Version="1.4.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="ThisAssembly" Version="2.1.2" />
     <PackageReference Include="ColoredConsole" Version="1.0.0" />
-    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console" Version="0.54.0" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="DotNetConfig" Version="1.2.0" />
     <PackageReference Include="git-credential-manager" Version="2.7.0" IncludeAssets="tools" GeneratePathProperty="true" />

--- a/src/File/Help.txt
+++ b/src/File/Help.txt
@@ -9,6 +9,9 @@ Actions
     sync       synchronizes with remote URLs, deleting local files and directories as needed
     update     updates local files from remote URLs, does not prune deleted remote files
 
+Options
+    sync --init [url]   honor new skip entries in an upstream init .netconfig
+
 Status
   = <- [url]   remote file equals local file
   ✓ <- [url]   local file updated with remote file

--- a/src/File/Program.cs
+++ b/src/File/Program.cs
@@ -44,6 +44,21 @@ class Program
         // Remove first arg which is the command to use.
         extraArgs.RemoveAt(0);
 
+        // Handle --init [url] option for the sync command.
+        if (command is SyncCommand sync &&
+            extraArgs.FindIndex(a => a == "--init") is var index && index >= 0)
+        {
+            if (index + 1 < extraArgs.Count && !extraArgs[index + 1].StartsWith('-'))
+            {
+                sync.InitUrl = extraArgs[index + 1];
+                extraArgs.RemoveRange(index, 2);
+            }
+            else
+            {
+                extraArgs.RemoveAt(index);
+            }
+        }
+
         // Add remainder arguments as if they were just files or urls provided 
         // to the command. Allows skipping the -f|-u switches.
         var skip = false;

--- a/src/File/SyncCommand.cs
+++ b/src/File/SyncCommand.cs
@@ -1,12 +1,66 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using ColoredConsole;
 using DotNetConfig;
 
 namespace Devlooped;
 
 class SyncCommand(Config configuration) : UpdateCommand(configuration)
 {
+    /// <summary>
+    /// Optional URL to a remote .netconfig whose skip=true entries are merged into
+    /// the local config before the sync runs (local entries always take precedence).
+    /// </summary>
+    public string? InitUrl { get; set; }
+
+    public override async Task<int> ExecuteAsync()
+    {
+        if (InitUrl != null)
+        {
+            var tempConfig = Path.GetTempFileName();
+            var tempFile = Path.GetTempFileName();
+            try
+            {
+                var addCmd = new AddCommand(Config.Build(tempConfig));
+                addCmd.Files.Add(new FileSpec(tempFile, new Uri(InitUrl)));
+
+                ColorConsole.WriteLine("Downloading init config file(s)...".Yellow());
+                await addCmd.ExecuteAsync();
+
+                var remoteConfig = Config.Build(tempFile);
+                var localConfig = Configuration;
+
+                foreach (var group in remoteConfig
+                    .Where(x => x.Level == null && x.Section == "file" && x.Subsection != null)
+                    .GroupBy(x => x.Subsection!))
+                {
+                    var path = group.Key;
+                    if (remoteConfig.GetBoolean("file", path, "skip") != true)
+                        continue;
+
+                    // Local entry takes precedence — only add skip if no local entry exists
+                    if (localConfig.Where(x => x.Section == "file" && x.Subsection == path).Any())
+                        continue;
+
+                    var url = remoteConfig.GetString("file", path, "url");
+                    if (url != null)
+                        localConfig = localConfig.SetString("file", path, "url", url);
+
+                    localConfig = localConfig.SetBoolean("file", path, "skip", true);
+                }
+            }
+            finally
+            {
+                File.Delete(tempConfig);
+                File.Delete(tempFile);
+            }
+        }
+
+        return await base.ExecuteAsync();
+    }
+
     protected override bool OnRemoteUrlMissing(FileSpec spec)
     {
         // If the file exists locally, delete it. Remove the config entry.

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Once a repo has been initialized from an upstream .netconfig, it basically loses its "memory" that it originally came from it. This means that subsequent (new) files in that repo, which may be added as skip=true in the seed .netconfig would be ignored on subsequent syncs and cause files to be synced that should not.

By specifying the new init url again when syncing, skipped files in upsteam will be honored before any sync happens.